### PR TITLE
Update Seasonal Clock URL in Footer

### DIFF
--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -18,7 +18,7 @@ export function Footer() {
         and was rendered{"  "}
         <a
           className={"underline"}
-          href="https://seasonal-hours-clock.netlify.app"
+          href="https://seasonalclock.org/"
         >
           {new Date().getMinutes()} minutes past{"  "}{getHourOf().shortName}
           {" "}


### PR DESCRIPTION
Hi @sgwilym ! Was just lurking through your blog as one does, and noticed the link to the seasonal clock at the footer points to a netlify URL that no longer resolves. 

I found the [seasonal-hours-clock](https://github.com/sgwilym/seasonal-hours-clock) repo and what seems like the current URL, so figured I'd throw in a quick PR here while I'm at it.

Cheers :)